### PR TITLE
Allow to force evaluation points in plot.gbm

### DIFF
--- a/R/plot.gbm.R
+++ b/R/plot.gbm.R
@@ -2,6 +2,7 @@ plot.gbm <- function(x,
                      i.var=1,
                      n.trees=x$n.trees,
                      continuous.resolution=100,
+                     grid.levels=NULL,
                      return.grid=FALSE,
                      type="link",
                      ...)
@@ -40,21 +41,41 @@ plot.gbm <- function(x,
    }
 
    # generate grid to evaluate gbm model
-   grid.levels <- vector("list",length(i.var))
-   for(i in 1:length(i.var))
-   {
-      # continuous
-      if(is.numeric(x$var.levels[[i.var[i]]]))
+   if (is.null(grid.levels)) {
+      grid.levels <- vector("list",length(i.var))
+      for(i in 1:length(i.var))
       {
-         grid.levels[[i]] <- seq(min(x$var.levels[[i.var[i]]]),
-                                 max(x$var.levels[[i.var[i]]]),
-                                 length=continuous.resolution)
+        # continuous
+        if(is.numeric(x$var.levels[[i.var[i]]]))
+        {
+           grid.levels[[i]] <- seq(min(x$var.levels[[i.var[i]]]),
+                                   max(x$var.levels[[i.var[i]]]),
+                                   length=continuous.resolution)
+        }
+        # categorical or ordered
+        else
+        {
+           grid.levels[[i]] <- as.numeric(factor(x$var.levels[[i.var[i]]],
+                                                 levels=x$var.levels[[i.var[i]]]))-1
+        }
       }
-      # categorical or ordered
-      else
-      {
-         grid.levels[[i]] <- as.numeric(factor(x$var.levels[[i.var[i]]],
-                                               levels=x$var.levels[[i.var[i]]]))-1
+   }
+   else
+   {
+      # allow grid.levels to not be a list when there is only one predictor
+      if (length(i.var) == 1 & !is.list(grid.levels)) {
+         grid.levels <- list(grid.levels)
+      }
+      # check compatibility in length, at least
+      if (length(grid.levels) != length(i.var)) {
+         stop("Need grid.levels for all variables in i.var")
+      }
+      # convert levels for categorical predictors into numbers
+      for(i in 1:length(i.var)) {
+         if(!is.numeric(x$var.levels[[i.var[i]]]))
+         {
+            grid.levels[[i]] <- as.numeric(grid.levels[[i]]) - 1
+         }
       }
    }
 

--- a/man/plot.gbm.Rd
+++ b/man/plot.gbm.Rd
@@ -9,6 +9,7 @@ Plots the marginal effect of the selected variables by "integrating" out the oth
      i.var = 1,
      n.trees = x$n.trees,
      continuous.resolution = 100,
+     grid.levels = NULL,
      return.grid = FALSE,
      type = "link",
      ...)
@@ -24,6 +25,14 @@ Plots the marginal effect of the selected variables by "integrating" out the oth
   \code{n.trees} trees will be used}
   \item{continuous.resolution}{ The number of equally space points at which to
   evaluate continuous predictors }
+  \item{grid.levels}{ A list containing the points at which to evaluate each
+  predictor in \code{i.var} (in the same order as \code{i.var}). For continuous
+  predictors this is usually a regular sequence of values within the range of the
+  variable. For categorical predictors, the points are the levels of the factor. When
+  \code{length(i.var)} is one, the values can be provided directly, outside a list.\n
+  This is NULL by default and generated automatically from the data, using
+  \code{continuous.resolution} for continuous predictors. Forcing the values can be
+  useful to evaluate two models on the same exact range }
   \item{return.grid}{ if \code{TRUE} then \code{plot.gbm} produces no graphics and only returns
   the grid of evaluation points and their average predictions. This is useful for
   customizing the graphics for special variable types or for dimensions greater


### PR DESCRIPTION
This is useful to evaluate the effects of two models on the exact same data
points. An example application is the evaluation of the confidence around
model effects through bootstraps. For each bootstrap, the data range will be 
slightly different and the points at which plot.gbm will evaluate the effect
of the predictor will also be slightly different, which complicates the
computation of a mean+range of effects afterwards.

The argument is not checked very much and the description in the help is a
little verbose but that's a start.
