### PR TITLE
Restore automatic multicore detection for CV

### DIFF
--- a/R/gbmCrossVal.R
+++ b/R/gbmCrossVal.R
@@ -99,7 +99,7 @@ gbmCrossValModelBuild <- function(cv.folds, cv.group, n.cores, i.train,
   seeds <- as.integer(runif(cv.folds, -(2^31 - 1), 2^31))
 
   ## now do the cross-validation model builds
-  if (!is.null(n.cores) && n.cores > 1){
+  if ( ! is.null(cluster) ){
     parallel::parLapply(cl=cluster, X=1:cv.folds,
             gbmDoFold, i.train, x, y, offset, distribution,
             w, var.monotone, n.trees,


### PR DESCRIPTION
When n.cores is NULL, gbmCluster() detects multiple core automatically and
creates a cluster when appropriate. The code introduced in commit 
9519046fe3bb49ad44dc to fix an issue with cluster detection checks n.cores
directly instead of checking the output of gbmCluster(). So what was
automatically parallelised before isn't anymore.

The current code checks the output of gbmCluster and still uses the  
non-parallel lapply() on machines with only one core.
