### PR TITLE
weighted quantile regression

### DIFF
--- a/R/gbm.fit.R
+++ b/R/gbm.fit.R
@@ -138,10 +138,6 @@ gbm.fit <- function(x,y,
    }
    if(distribution$name == "quantile")
    {
-      if(length(unique(w)) > 1)
-      {
-         stop("This version of gbm for the quantile regression lacks a weighted quantile. For now the weights must be constant.")
-      }
       if(is.null(distribution$alpha))
       {
          stop("For quantile regression, the distribution parameter must be a list with a parameter 'alpha' indicating the quantile, for example list(name=\"quantile\",alpha=0.95).")

--- a/src/quantile.h
+++ b/src/quantile.h
@@ -89,6 +89,7 @@ public:
 
 private:
     vector<double> vecd;
+    vector<double> vecw;
     double dAlpha;
 };
 


### PR DESCRIPTION
Dear Harry,

This is to enable a weighted quantile regression. We used this code in one of our projects (on top of gbm 2.1).

We also created an example to ensure that the output of the truly weighted regression roughly corresponds to the output of unweighted quantile regression where observations are repeated according to the weights.

This example can be downloaded from http://boytsov.info/tmp/examplefilesforgbmquantile.tar.gz

**An important note:** the R-wrapper in the master branch appears **to be broken**. We can run this example in gbm 2.1-0.3 (with a minimum change of C++ code, namely, using unsigned long * aiNodeAssign instead of the vector std::vector<unsigned long>& aiNodeAssign). Yet, the example crashes when we run using the **master** branch.

Furthermore, the unweighted quantile regression crashes even if we use the **unmodified master branch.**

--
Leo & Anna