### PR TITLE
In gbm()  the verbose parameter should be a boolean instead a string

### DIFF
--- a/R/gbm.R
+++ b/R/gbm.R
@@ -22,13 +22,13 @@ gbm <- function(formula = formula(data),
                 mFeatures = NULL,
                 cv.folds=0,
                 keep.data = TRUE,
-                verbose = 'CV',
+                verbose = TRUE,
                 class.stratify.cv=NULL,
                 n.cores=NULL){
    theCall <- match.call()
 
 
-   lVerbose <- if (!is.logical(verbose)) { FALSE }
+   lVerbose <- if (!is.logical(verbose)) { warning('the verbose parameter should be a boolean'); FALSE }
                else { verbose }
 
    mf <- match.call(expand.dots = FALSE)

--- a/man/gbm.Rd
+++ b/man/gbm.Rd
@@ -21,7 +21,7 @@ gbm(formula = formula(data),
     mFeatures = NULL,
     cv.folds=0,
     keep.data = TRUE,
-    verbose = "CV",
+    verbose = FALSE,
     class.stratify.cv=NULL,
     n.cores = NULL)
 


### PR DESCRIPTION
It looks like the old default value of 'CV' was a typo.  This makes the default value of verbose in gbm() consistent with gbm.fit() but changes it from FALSE to TRUE.
