### PR TITLE
Use makeCluster() from parallel package instead of another package such ...

### DIFF
--- a/R/gbmCluster.R
+++ b/R/gbmCluster.R
@@ -5,5 +5,5 @@ gbmCluster <- function(n){
       n <- detectCores()
     }
     if (n == 1){ NULL }
-    else { makeCluster(n) }
+    else { parallel::makeCluster(n) }
 }


### PR DESCRIPTION
...as snow.

The following command finds masked functions between snow and parallel.
`grep -P "(clusterApply|clusterApplyLB|clusterCall|clusterEvalQ|clusterExport|clusterMap|clusterSplit|makeCluster|parApply|parCapply|parLapply|parRapply|parSapply|splitIndices|stopCluster)" R/*R`
