### PR TITLE
Modified CV strategy for decent speedup

### DIFF
--- a/R/gbm.R
+++ b/R/gbm.R
@@ -138,17 +138,21 @@ gbm <- function(formula = formula(data),
     }
 
    cv.error <- NULL
+
+   # If CV is used, final model is calculated within the cluster
    if(cv.folds>1) {
      cv.results <- gbmCrossVal(cv.folds, nTrain, n.cores,
                                class.stratify.cv, data,
                                x, y, offset, distribution, w, var.monotone,
                                n.trees, interaction.depth, n.minobsinnode,
                                shrinkage, bag.fraction, mFeatures,
-                               var.names, response.name, group)
+                               var.names, response.name, group, lVerbose, keep.data)
      cv.error <- cv.results$error
-     p <- cv.results$predictions
-   } # Close if(cv.folds > 1
+     p        <- cv.results$predictions
+     gbm.obj  <- cv.results$all.model
+   } 
 
+   else {
    gbm.obj <- gbm.fit(x,y,
                       offset = offset,
                       distribution = distribution,
@@ -166,6 +170,7 @@ gbm <- function(formula = formula(data),
                       var.names = var.names,
                       response.name = response.name,
                       group = group)
+   }
 
    gbm.obj$train.fraction <- train.fraction
    gbm.obj$Terms <- Terms

--- a/R/gbmDoFold.R
+++ b/R/gbmDoFold.R
@@ -1,31 +1,52 @@
-gbmDoFold <-
-    # Do specified cross-validation fold - a self-contained function for
-    # passing to individual cores.
-function(X,
+gbmDoFold <- function(X,
          i.train, x, y, offset, distribution, w, var.monotone, n.trees,
          interaction.depth, n.minobsinnode, shrinkage, bag.fraction, mFeatures,
-         cv.group, var.names, response.name, group, s){
+         cv.group, var.names, response.name, group, s, lVerbose, keep.data, nTrain){
+    # Do specified cross-validation fold - a self-contained function for
+    # passing to individual cores.
+
     library(gbm, quietly=TRUE)
-    cat("CV:", X, "\n")
+    
+    # Handle the final model case separately
+    if (X == 0){
+      res <- gbm.fit(x,y,
+                       offset = offset,
+                       distribution = distribution,
+                       w = w,
+                       var.monotone = var.monotone,
+                       n.trees = n.trees,
+                       interaction.depth = interaction.depth,
+                       n.minobsinnode = n.minobsinnode,
+                       shrinkage = shrinkage,
+                       bag.fraction = bag.fraction,
+                       nTrain = nTrain,
+                       mFeatures = mFeatures,
+                       keep.data = keep.data,
+                       verbose = lVerbose,
+                       var.names = var.names,
+                       response.name = response.name,
+                       group = group)
+    }
+    else {
+      cat("CV:", X, "\n")
+      set.seed(s[[X]])
+      i <- order(cv.group == X)
+      x <- x[i.train,,drop=FALSE][i,,drop=FALSE]
+      y <- y[i.train][i]
+      offset <- offset[i.train][i]
+      nTrain <- length(which(cv.group != X))
+      group <- group[i.train][i]
 
-    set.seed(s[[X]])
-
-    i <- order(cv.group == X)
-    x <- x[i.train,,drop=FALSE][i,,drop=FALSE]
-    y <- y[i.train][i]
-    offset <- offset[i.train][i]
-    nTrain <- length(which(cv.group != X))
-    group <- group[i.train][i]
-
-    res <- gbm.fit(x, y,
-                   offset=offset, distribution=distribution,
-                   w=w, var.monotone=var.monotone, n.trees=n.trees,
-                   interaction.depth=interaction.depth,
-                   n.minobsinnode=n.minobsinnode,
-                   shrinkage=shrinkage,
-                   bag.fraction=bag.fraction,
-                   nTrain=nTrain, mFeatures=mFeatures, keep.data=FALSE,
-                   verbose=FALSE, response.name=response.name,
-                   group=group)
-    res
+      res <- gbm.fit(x, y,
+                     offset=offset, distribution=distribution,
+                     w=w, var.monotone=var.monotone, n.trees=n.trees,
+                     interaction.depth=interaction.depth,
+                     n.minobsinnode=n.minobsinnode,
+                     shrinkage=shrinkage,
+                     bag.fraction=bag.fraction,
+                     nTrain=nTrain, mFeatures=mFeatures, keep.data=FALSE,
+                     verbose=FALSE, response.name=response.name,
+                     group=group)
+  }
+  res
 }


### PR DESCRIPTION
The original strategy for cross validation was to fit the CV folds in parallel, and then start on the final model on a single thread once all the folds are finished. If there are cores and memory to spare, there is a significant speedup from fitting the final model in parallel along with the CV folds. 

The folds are only used to inform the optimal tree depth: no information is passed between the CV fold models and the final model. Nothing is lost from making the whole thing parallel.

Supplying n.cores = cv.folds + 1 shows a huge speedup, about 30 to 40% (making the whole thing about as fast as not using CV at all). When n.cores <= cv.folds, there is a more modest speedup (the work of fitting the final model can be taken up earlier by any idle thread).