### PR TITLE
Fix bug in predict.gbm

### DIFF
--- a/R/predict.gbm.R
+++ b/R/predict.gbm.R
@@ -12,7 +12,7 @@ predict.gbm <- function(object,newdata,n.trees,
       } else if (!is.null(object$cv.error)){
          n.trees <- gbm.perf( object, method="cv", plot.it = FALSE )
       } else{
-        best <- length(object$train.error)
+        n.trees <- length(object$train.error)
       }
       message(paste("Using", n.trees, "trees...\n"))
    } else if (length(n.trees) == 0){


### PR DESCRIPTION
The local variable 'best' was never referred to and predict.gbm would crash if n.trees wasn't supplied as an argument.  Clearly the default value for n.trees should be the maximum number of trees trained, and I believe that is the intention of the if block.