### PR TITLE
Shrinkage as a vector and learning rate decay

### DIFF
--- a/R/gbm.R
+++ b/R/gbm.R
@@ -17,6 +17,7 @@ gbm <- function(formula = formula(data),
                 interaction.depth = 1,
                 n.minobsinnode = 10,
                 shrinkage = 0.001,
+                shrinkage.decay = 0,
                 bag.fraction = 0.5,
                 train.fraction = 1.0,
                 mFeatures = NULL,
@@ -135,6 +136,15 @@ gbm <- function(formula = formula(data),
       } else {
         mFeatures <- max(mFeatures, 1)
       }
+    }
+
+    # Determine shrinkage vector
+    if (length(shrinkage) > 1 && length(shrinkage) != n.trees){
+      stop("Shrinkage as a vector must have length n.trees.")
+    } else if (length(shrinkage) == 1){
+      # Determine shrinkage vector using shrinkage.decay
+      shrinkage <- sapply(1:n.trees,
+                          function(i) shrinkage[1] / (1+(i-1)*shrinkage.decay))
     }
 
    cv.error <- NULL

--- a/R/gbm.fit.R
+++ b/R/gbm.fit.R
@@ -53,7 +53,12 @@ gbm.fit <- function(x,y,
    if(is.null(var.names)) {
        var.names <- getVarNames(x)
    }
-
+    
+   if (length(shrinkage) == 1){
+     shrinkage <- rep(shrinkage, n.trees)
+   } else if (length(shrinkage) != n.trees){
+     stop("Shrinkage as a vector must have length n.trees.")
+   }
 #   if(is.null(response.name)) { response.name <- "y" }
 
    # check dataset size

--- a/R/gbm.more.R
+++ b/R/gbm.more.R
@@ -8,6 +8,9 @@ gbm.more <- function(object,
    theCall <- match.call()
    nTrain  <- object$nTrain
 
+   shrinkage <- object$shrinkage[length(object$shrinkage)]
+   shrinkage <- rep(shrinkage, n.new.trees)
+
    if (object$distribution$name != "pairwise")
    {
       distribution.call.name <- object$distribution$name
@@ -125,7 +128,6 @@ gbm.more <- function(object,
          {
             stop("Metrics 'map' and 'mrr' require the response to be in {0,1}")
          }
-
          # Cut-off rank for metrics
          # We pass this argument as the last element in the Misc vector
          # Default of 0 means no cutoff
@@ -197,7 +199,7 @@ gbm.more <- function(object,
                     interaction.depth = as.integer(object$interaction.depth),
                     n.minobsinnode = as.integer(object$n.minobsinnode),
                     n.classes = as.integer(object$num.classes),
-                    shrinkage = as.double(object$shrinkage),
+                    shrinkage = as.double(shrinkage),
                     bag.fraction = as.double(object$bag.fraction),
                     train.fraction = as.integer(nTrain), #Should this be as.double(train.fraction)
                     mFeatures = as.integer(object$mFeatures),

--- a/src/gbm.cpp
+++ b/src/gbm.cpp
@@ -48,7 +48,7 @@ unsigned long gbm_setup
     int cDepth,
     int cMinObsInNode,
     int cNumClasses,
-    double dShrinkage,
+    double *dShrinkage,
     double dBagFraction,
     int cTrain,
     int cFeatures,
@@ -163,7 +163,8 @@ GBMRESULT gbm_transfer_to_R
     double *adErrorReduction,
     double *adWeight,
     double *adPred,
-    int cCatSplitsOld
+    int cCatSplitsOld,
+    double currentShrinkage
 )
 {
     GBMRESULT hr = GBM_OK;
@@ -178,7 +179,8 @@ GBMRESULT gbm_transfer_to_R
                                    adWeight,
                                    adPred,
                                    vecSplitCodes,
-                                   cCatSplitsOld);
+                                   cCatSplitsOld,
+                                   currentShrinkage);
     if(GBM_FAILED(hr)) goto Error;
 
 Cleanup:

--- a/src/gbm.h
+++ b/src/gbm.h
@@ -54,7 +54,7 @@ GBMRESULT gbm_setup
     int cLeaves,
     int cMinObsInNode,
     int cNumClasses,
-    double dShrinkage,
+    double *dShrinkage,
     double dBagFraction,
     int cTrain,
     int cFeatures,
@@ -76,7 +76,8 @@ GBMRESULT gbm_transfer_to_R
     double *adErrorReduction,
     double *adWeight,
     double *adPred,
-    int cCatSplitsOld
+    int cCatSplitsOld,
+    double currentShrinkage
 );
 
 

--- a/src/gbm_engine.h
+++ b/src/gbm_engine.h
@@ -35,7 +35,7 @@ public:
     ~CGBM();
     GBMRESULT Initialize(CDataset *pData,
                          CDistribution *pDist,
-                         double dLambda,
+                         double *dLambda,
                          unsigned long nTrain,
                          unsigned long cFeatures,
                          double dBagFraction,
@@ -50,7 +50,8 @@ public:
                     double &dOOBagImprove,
                     int &cNodes,
 					int cNumClasses,
-					int cClassIdx);
+					int cClassIdx,
+                    int iT);
     GBMRESULT TransferTreeToRList(int *aiSplitVar,
                                 double *adSplitPoint,
                                 int *aiLeftNode,
@@ -60,7 +61,8 @@ public:
                                 double *adWeight,
                                 double *adPred,
                                 VEC_VEC_CATEGORIES &vecSplitCodes,
-                                int cCatSplitsOld);
+                                int cCatSplitsOld,
+                                double currentShrinkage);
     GBMRESULT Predict(unsigned long iVar,
                     unsigned long cTrees,
                     double *adF,
@@ -94,14 +96,16 @@ public:
     std::vector<double> adZ;
     std::vector<double> adFadj;
 
-    double dLambda;
+    double *dLambda;
     unsigned long cTrain;
     unsigned long cValid;
     unsigned long cFeatures;
     unsigned long cTotalInBag;
     double dBagFraction;
+    double currentShrinkage;
     unsigned long cDepth;
     unsigned long cMinObsInNode;
+    int  iT;
     int  cGroups;
 };
 

--- a/src/gbmentry.cpp
+++ b/src/gbmentry.cpp
@@ -105,7 +105,7 @@ SEXP gbm
                    INTEGER(rcDepth)[0],
                    INTEGER(rcMinObsInNode)[0],
                    INTEGER(rcNumClasses)[0],
-                   REAL(rdShrinkage)[0],
+                   REAL(rdShrinkage),
                    REAL(rdBagFraction)[0],
                    INTEGER(rcTrain)[0],
                    INTEGER(rcFeatures)[0],
@@ -124,7 +124,7 @@ SEXP gbm
     // initialize the GBM
     hr = pGBM->Initialize(pData,
                           pDist,
-                          REAL(rdShrinkage)[0],
+                          REAL(rdShrinkage),
                           cTrain,
                           cFeatures,
                           REAL(rdBagFraction)[0],
@@ -214,7 +214,7 @@ SEXP gbm
         {
             hr = pGBM->iterate(REAL(radF),
                                dTrainError,dValidError,dOOBagImprove,
-                               cNodes, cNumClasses, iK);
+                               cNodes, cNumClasses, iK, iT);
 
             if(GBM_FAILED(hr))
             {
@@ -260,7 +260,8 @@ SEXP gbm
                                    REAL(rdErrorReduction),
                                    REAL(rdWeight),
                                    REAL(rdPred),
-                                   INTEGER(rcCatSplitsOld)[0]);
+                                   INTEGER(rcCatSplitsOld)[0],
+                                   REAL(rdShrinkage)[iT]);
         } // Close for iK
 
         // print the information
@@ -276,7 +277,7 @@ SEXP gbm
                        iT+1+INTEGER(rcTreesOld)[0],
                        REAL(radTrainError)[iT],
                        REAL(radValidError)[iT],
-                       REAL(rdShrinkage)[0],
+                       REAL(rdShrinkage)[iT],
                        REAL(radOOBagImprove)[iT]);
             }
         }


### PR DESCRIPTION
Some changes to the c++ to allow the user to give shrinkage as a vector, or to supply shrinkage.decay as a parameter. The general idea is let gbm learn quickly at first but slower as trees get added. 

All old code will (AKA should) still work, I've tested this on a bunch of Gaussian and Laplacian models. Giving shrinkage as a non-vector, gbm.fit and gbm.more all work just fine.